### PR TITLE
Type system update (partial) issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
+dummy/
+*.ipynb
+
 .env
 .github/
 bin/
 .papi
-dummy/
 tsconfig.vitest-temp.json
+deno.json
 
 node_modules/
 *lock.json

--- a/src/app-handler/app.ts
+++ b/src/app-handler/app.ts
@@ -11,7 +11,7 @@ export enum WatchType {
 /**
  * A function that launches & handles a `TRoute` specification
  */
-export type RouteHandler = (context: Context<any>) => void;
+export type RouteHandler = (context: Context<ChainId>) => void;
 
 /**
  * The object that is derived from loading an `AppModule` specification
@@ -31,7 +31,6 @@ export class LambdaApp {
         public name: string,
         public description: string,
         public alive: boolean,
-        public watchPaths: WatchLeaf[],
         public chains: ChainId[],
         public handlers: RouteHandler[],
         public logs: string[] = []

--- a/src/app-handler/app.ts
+++ b/src/app-handler/app.ts
@@ -5,7 +5,7 @@ import { ChainId, Context, WatchLeaf } from "@lambdas/app-support";
  */
 export enum WatchType {
     EVENT = "event",
-    QUERY = "query",
+    STORAGE = "storage",
 }
 
 /**

--- a/src/app-handler/app.ts
+++ b/src/app-handler/app.ts
@@ -1,4 +1,4 @@
-import { ChainId, Context, WatchPath } from "@lambdas/app-support";
+import { ChainId, Context, WatchLeaf } from "@lambdas/app-support";
 
 /**
  * The set of valid root `Observables`
@@ -31,7 +31,7 @@ export class LambdaApp {
         public name: string,
         public description: string,
         public alive: boolean,
-        public watchPaths: WatchPath[],
+        public watchPaths: WatchLeaf[],
         public chains: ChainId[],
         public handlers: RouteHandler[],
         public logs: string[] = []

--- a/src/app-handler/loader.ts
+++ b/src/app-handler/loader.ts
@@ -188,8 +188,7 @@ export async function loadApps(appsDir: string, manager: AppsManager) {
 
 if (import.meta.vitest) {
     const { test, expect, describe } = import.meta.vitest;
-
-    test("Correct event observable", () => {
+    test("TODO! Implement tests", () => {
         expect("").toEqual("todo!");
     });
 }

--- a/src/app-handler/loader.ts
+++ b/src/app-handler/loader.ts
@@ -33,7 +33,9 @@ type WatchEntriesPayload = {
 
 /**
  * Creates a route handler from a route and an API
- * TODO! refactor & better types
+ *
+ * TODO! refactor & better types. whole thing needs
+ *       to be validated w/ integration tests next.
  */
 async function handlerFromRoute<WLs extends WatchLeaf[]>(
     route: TRoute<WLs>,
@@ -66,8 +68,6 @@ async function handlerFromRoute<WLs extends WatchLeaf[]>(
                 const nArgs: number = codec.args.inner.length;
                 leafHandlers.push((context: Context<ChainId>) => {
                     // Decide to use `watchValue` or `watchEntries` based on available args
-                    // TODO! On `watchEntries` need to map `deleted` & `upsert` entries
-                    // TODO! have to map payload the format that apps expect
                     if (leaf.args.length < nArgs) {
                         watchable
                             .watchEntries(
@@ -77,8 +77,6 @@ async function handlerFromRoute<WLs extends WatchLeaf[]>(
                                     : { at: "best" }
                             )
                             .forEach(async (payload: WatchEntriesPayload) => {
-                                // TODO! Transform payload into format we expect.
-                                // Take into account `leaf.options.changeType`.
                                 const refinedPayloads = payload.entries.map(
                                     (p) => {
                                         return { key: p.args, value: p.value };

--- a/src/app-handler/manager.ts
+++ b/src/app-handler/manager.ts
@@ -99,7 +99,7 @@ export class AppsManager {
                 chalk.green(app.name) +
                 "    " +
                 chalk.white.bold("watching ") +
-                chalk.grey(app.watchPaths)
+                chalk.grey(`[${app.chains.join(", ")}]`)
         );
         console.log(chalk.grey(app.description) + "\n");
     }
@@ -113,11 +113,6 @@ export class AppsManager {
         this.apps.forEach((app) => {
             this.logLaunchStatus(app);
             if (app.alive) {
-                const dd = app.chains.reduce((acc, chainId) => {
-                    acc[toVirtual(chainId)] = this.apis[chainId];
-                    return acc;
-                }, {} as Record<VirtualChainId, TypedApi<any>>);
-
                 const context = new Context(
                     Object.fromEntries(
                         app.chains.map(

--- a/src/app-support/types/apps.ts
+++ b/src/app-support/types/apps.ts
@@ -1,20 +1,12 @@
 import * as D from "@polkadot-api/descriptors";
 
-import { PayloadLookup, Split } from "./helpers";
+import { Payload } from "./payload";
 import { WatchLeaf } from "./descriptor-trees";
 import { Context } from "../context";
 
 /**
  * The expected type of a payload for a given `WatchPath`
  */
-export type Payload<WP extends WatchLeaf> = PayloadLookup<
-    {
-        event: (typeof D)[WP["chain"]]["descriptors"]["pallets"]["__event"];
-
-        storage: (typeof D)[WP["chain"]]["descriptors"]["pallets"]["__storage"];
-    },
-    Split<WP["path"]>
->;
 
 /**
  * Specifies a single route within an lambda application.

--- a/src/app-support/types/apps.ts
+++ b/src/app-support/types/apps.ts
@@ -27,7 +27,7 @@ export type Payload<WP extends WatchLeaf> = PayloadLookup<
  */
 export interface TRoute<
     WP extends WatchLeaf[],
-    WPs extends readonly WatchLeaf[][] = []
+    WPs extends readonly WatchLeaf[][] = [WP]
 > {
     watching: WP;
     trigger: (

--- a/src/app-support/types/apps.ts
+++ b/src/app-support/types/apps.ts
@@ -66,17 +66,6 @@ if (import.meta.vitest) {
     const { test, expectTypeOf } = import.meta.vitest;
     const { Observables } = await import("./descriptor-trees");
 
-    // test("`WatchPath` structured type strings", () => {
-    //     expectTypeOf<"polkadot_asset_hub.event.balances.Transfer">().toExtend<WatchPath>();
-    //     expectTypeOf<"not_a_chain.event.balances.Transfer">().not.toExtend<WatchPath>();
-    // });
-
-    // test("`PartsOf` should properly split ChainIds from `WatchPath`", () => {
-    //     expectTypeOf<
-    //         PartsOf<"polkadot.thisPart.can_be.Anything...">
-    //     >().toEqualTypeOf<["polkadot", "thisPart.can_be.Anything..."]>();
-    // });
-
     test("`Payload` should capture correct `Observable` payload for a given `WatchPath`", () => {
         expectTypeOf<
             Payload<{
@@ -95,7 +84,7 @@ if (import.meta.vitest) {
         }>();
 
         const st_obs =
-            Observables.storage.polkadotAssetHub.Balances.Account("id");
+            Observables.storage.polkadotAssetHub.Balances.Account("some-id");
         expectTypeOf<Payload<(typeof st_obs)[number]>>().toEqualTypeOf<{
             key: [SS58String];
             value: {

--- a/src/app-support/types/apps.ts
+++ b/src/app-support/types/apps.ts
@@ -1,33 +1,19 @@
 import * as D from "@polkadot-api/descriptors";
 
-import { DeepLookup, DescriptorTree } from "./helpers";
-import { ChainId } from "./known-chains";
+import { PayloadLookup, Split } from "./helpers";
+import { WatchLeaf } from "./descriptor-trees";
 import { Context } from "../context";
-
-/**
- * Expected format of a `<TRoute>.watching` string:
- */
-export type WatchPath = `${ChainId}.${string}`;
-
-/**
- * Extract the `ChainId` and rest-of-path: `string` from a `WatchPath`
- */
-export type PartsOf<WP extends WatchPath> =
-    WP extends `${infer C}.${infer Rest}` ? [C, Rest] : never;
 
 /**
  * The expected type of a payload for a given `WatchPath`
  */
-export type Payload<WP extends WatchPath> = DeepLookup<
+export type Payload<WP extends WatchLeaf> = PayloadLookup<
     {
-        event: DescriptorTree<
-            (typeof D)[PartsOf<WP>[0]]["descriptors"]["pallets"]["__event"]
-        >;
-        query: DescriptorTree<
-            (typeof D)[PartsOf<WP>[0]]["descriptors"]["pallets"]["__storage"]
-        >;
+        event: (typeof D)[WP["chain"]]["descriptors"]["pallets"]["__event"];
+
+        storage: (typeof D)[WP["chain"]]["descriptors"]["pallets"]["__storage"];
     },
-    PartsOf<WP>[1]
+    Split<WP["path"]>
 >;
 
 /**
@@ -39,22 +25,25 @@ export type Payload<WP extends WatchPath> = DeepLookup<
  * @property trigger  - Specifies the conditions under which we will take some `lambda` action
  * @property lambda   - The action to upon `trigger`'s conditions being satisfied
  */
-export interface TRoute<WP extends WatchPath, WPs extends WatchPath[] = []> {
+export interface TRoute<
+    WP extends WatchLeaf[],
+    WPs extends readonly WatchLeaf[][] = []
+> {
     watching: WP;
     trigger: (
-        payload: Payload<WP>,
-        context: Context<PartsOf<WPs[number]>[0]>
+        payload: Payload<WP[0]>, // TODO! should be union of all WatchLeafs
+        context: Context<WPs[number][number]["chain"]>
     ) => boolean | Promise<boolean>;
     lambda: (
-        payload: Payload<WP>,
-        context: Context<PartsOf<WPs[number]>[0]>
+        payload: Payload<WP[0]>, // TODO! should be union of all WatchLeafs
+        context: Context<WPs[number][number]["chain"]>
     ) => void | Promise<void>;
 }
 
 /**
  * Specifies a complete lambda application as a collection of routes and some peripheral settings.
  */
-export interface TAppModule<WPs extends WatchPath[]> {
+export interface TAppModule<WPs extends readonly WatchLeaf[][]> {
     description: string;
     routes: { [K in keyof WPs]: TRoute<WPs[K], WPs> };
 }
@@ -62,7 +51,7 @@ export interface TAppModule<WPs extends WatchPath[]> {
 /**
  * Convenience builder function for specifying a lambda `TAppModule` with built-in type hints.
  */
-export function App<WPs extends WatchPath[]>(
+export function App<const WPs extends readonly WatchLeaf[][]>(
     description: string,
     ...routes: { [K in keyof WPs]: TRoute<WPs[K], WPs> }
 ): TAppModule<WPs> {
@@ -77,36 +66,56 @@ if (import.meta.vitest) {
     const { test, expectTypeOf } = import.meta.vitest;
     const { Observables } = await import("./descriptor-trees");
 
-    test("`WatchPath` structured type strings", () => {
-        expectTypeOf<"polkadot_asset_hub.event.balances.Transfer">().toExtend<WatchPath>();
-        expectTypeOf<"not_a_chain.event.balances.Transfer">().not.toExtend<WatchPath>();
-    });
+    // test("`WatchPath` structured type strings", () => {
+    //     expectTypeOf<"polkadot_asset_hub.event.balances.Transfer">().toExtend<WatchPath>();
+    //     expectTypeOf<"not_a_chain.event.balances.Transfer">().not.toExtend<WatchPath>();
+    // });
 
-    test("`PartsOf` should properly split ChainIds from `WatchPath`", () => {
-        expectTypeOf<
-            PartsOf<"polkadot.thisPart.can_be.Anything...">
-        >().toEqualTypeOf<["polkadot", "thisPart.can_be.Anything..."]>();
-    });
+    // test("`PartsOf` should properly split ChainIds from `WatchPath`", () => {
+    //     expectTypeOf<
+    //         PartsOf<"polkadot.thisPart.can_be.Anything...">
+    //     >().toEqualTypeOf<["polkadot", "thisPart.can_be.Anything..."]>();
+    // });
 
     test("`Payload` should capture correct `Observable` payload for a given `WatchPath`", () => {
         expectTypeOf<
-            Payload<"polkadot.event.doesnt.exist">
+            Payload<{
+                chain: "polkadot";
+                path: "event.doesnt.exist";
+                args: [];
+                options: {};
+            }>
         >().toEqualTypeOf<never>();
-        expectTypeOf<
-            Payload<typeof Observables.event.polkadot.Balances.Transfer>
-        >().toEqualTypeOf<{
+
+        const ev_obs = Observables.event.polkadot.Balances.Transfer();
+        expectTypeOf<Payload<(typeof ev_obs)[number]>>().toEqualTypeOf<{
             from: SS58String;
             to: SS58String;
             amount: bigint;
         }>();
-        expectTypeOf<
-            Payload<typeof Observables.query.polkadotAssetHub.System.Number>
-        >().toEqualTypeOf<number>();
+
+        const st_obs =
+            Observables.storage.polkadotAssetHub.Balances.Account("id");
+        expectTypeOf<Payload<(typeof st_obs)[number]>>().toEqualTypeOf<{
+            key: [SS58String];
+            value: {
+                free: bigint;
+                reserved: bigint;
+                frozen: bigint;
+                flags: bigint;
+            };
+        }>();
+
+        const st2_obs = Observables.storage.polkadotAssetHub.System.Number();
+        expectTypeOf<Payload<(typeof st2_obs)[number]>>().toEqualTypeOf<{
+            key: [];
+            value: number;
+        }>();
     });
 
     test("`App` function propagates correct payload type", () => {
         App("test", {
-            watching: Observables.event.polkadot.Bounties.BountyProposed,
+            watching: Observables.event.polkadot.Bounties.BountyProposed(),
             trigger: (payload, _) => {
                 expectTypeOf<typeof payload>().toEqualTypeOf<{
                     index: number;
@@ -125,7 +134,7 @@ if (import.meta.vitest) {
         App(
             "test",
             {
-                watching: Observables.event.polkadot.Bounties.BountyProposed,
+                watching: Observables.event.polkadot.Bounties.BountyProposed(),
                 trigger: (_, c) => {
                     expectTypeOf<typeof c.apis>().toEqualTypeOf<{
                         polkadot: TypedApi<(typeof D)["polkadot"]>;
@@ -136,7 +145,8 @@ if (import.meta.vitest) {
                 lambda: (_, __) => {},
             },
             {
-                watching: Observables.event.rococoV2_2.Bounties.BountyProposed,
+                watching:
+                    Observables.event.rococoV2_2.Bounties.BountyProposed(),
                 trigger: (_, __) => true,
                 lambda: (_, c) => {
                     expectTypeOf<typeof c.apis>().toEqualTypeOf<{
@@ -146,5 +156,9 @@ if (import.meta.vitest) {
                 },
             }
         );
+    });
+
+    test("test123", async () => {
+        const polkadot = D.polkadot;
     });
 }

--- a/src/app-support/types/apps.ts
+++ b/src/app-support/types/apps.ts
@@ -1,7 +1,7 @@
 import * as D from "@polkadot-api/descriptors";
 
 import { Payload } from "./payload";
-import { WatchLeaf } from "./descriptor-trees";
+import { WatchLeaf } from "./observables";
 import { Context } from "../context";
 
 /**
@@ -56,7 +56,7 @@ export function App<const WPs extends readonly WatchLeaf[][]>(
 import type { SS58String, TypedApi } from "polkadot-api";
 if (import.meta.vitest) {
     const { test, expectTypeOf } = import.meta.vitest;
-    const { Observables } = await import("./descriptor-trees");
+    const { Observables } = await import("./observables");
 
     test("`Payload` should capture correct `Observable` payload for a given `WatchPath`", () => {
         expectTypeOf<

--- a/src/app-support/types/descriptor-trees.ts
+++ b/src/app-support/types/descriptor-trees.ts
@@ -29,7 +29,7 @@ export type WatchLeaf<
     C extends ChainId = ChainId,
     P extends string = string,
     A extends any[] = any[],
-    O extends object = any
+    O extends object = EventOptions & StorageOptions
 > = Expand<{ chain: C; path: P; args: A; options: O }>;
 
 /**
@@ -109,13 +109,15 @@ async function buildFuncTree<
                 /**
                  * Is the last argument an "options" object?
                  *
-                 * NOTE! In the case that no options are provided, and the last given key
-                 * is an object who's properties all match the available properties some
-                 * "options" object, then this will give a false positive, mistakenly eating
-                 * a key as our "options".
+                 * NOTE! In the case that no options are provided, and the last given *key*
+                 * is an object who's properties all match the available properties of some
+                 * *options* object, then this will give a false positive, mistakenly eating
+                 * a *key* as our *options*.
                  *
-                 * The chances of this conflict actually happening are very low, so for now
-                 * we accept this potential edge case for the sake of nice API design.
+                 * The chances of this conflict actually happening are very low and an easy fix,
+                 * (use builder pattern .withOptions() which internally creates an explicit
+                 * `new StorageOptions()/EventOptions()`) so for now we accept this potential
+                 * edge case for the sake of nice API design.
                  */
                 typeof lastArg === "object" &&
                 (Object.keys(lastArg).every((key) =>

--- a/src/app-support/types/descriptor-trees.ts
+++ b/src/app-support/types/descriptor-trees.ts
@@ -1,78 +1,153 @@
 import * as D from "@polkadot-api/descriptors";
-import { PathMap } from "./helpers";
+import { Expand, PartialArgs } from "./helpers";
 import {
     knownChains,
     toVirtual,
     FromVirtual,
     VirtualChainId,
+    ChainId,
 } from "./known-chains";
+import { PlainDescriptor, StorageDescriptor } from "polkadot-api";
 
-async function buildPaths<T extends object, P extends string>(
-    prefix: P,
-    tree: T
-): Promise<PathMap<T, P> | Promise<string>> {
-    const out = {} as any;
-    let isLeaf = true;
+/**
+ *
+ */
+export type WatchLeaf<
+    C extends ChainId = ChainId,
+    P extends string = string,
+    A extends any[] = any[],
+    O extends object = object
+> = Expand<{ chain: C; path: P; args: A; options: O }>;
+
+/**
+ *
+ */
+export type FuncTree<T, P extends string, C extends ChainId> = {
+    [K in keyof T]: T[K] extends StorageDescriptor<infer Keys, any, any, any>
+        ? (
+              ...args: PartialArgs<Keys>
+          ) => [WatchLeaf<C, `${P}.${K & string}`, PartialArgs<Keys>, {}>]
+        : T[K] extends PlainDescriptor<any>
+        ? () => [WatchLeaf<C, `${P}.${K & string}`, [], {}>]
+        : FuncTree<T[K], P extends "" ? K & string : `${P}.${K & string}`, C>;
+};
+
+// async function buildPaths<
+//     C extends ChainId,
+//     P extends string,
+//     T extends object
+// >(chain: C, prefix: P, tree: T): Promise<FuncTree<T, P, C> | Promise<WatchLeaf>> {
+//     const out = {} as any;
+//     let isLeaf = true;
+//     for (const key of Object.keys(tree) as Array<keyof T>) {
+//         const node = (tree as any)[key];
+//         const q = prefix ? `${prefix}.${key as string}` : (key as string);
+
+//         if (node && typeof node === "object" && "_type" in node) {
+//             out[key] = await q;
+//         } else {
+//             out[key] = await buildPaths(q as any, node);
+//             isLeaf = false;
+//         }
+//     }
+//     if (isLeaf) {
+//         return prefix as string;
+//     }
+//     return out;
+// }
+
+function buildFuncPaths<
+    T extends object,
+    C extends ChainId,
+    P extends string = ""
+>(prefix: P, tree: T, chain: C): FuncTree<T, P, C> {
+    const out: any = {};
     for (const key of Object.keys(tree) as Array<keyof T>) {
         const node = (tree as any)[key];
-        const q = prefix ? `${prefix}.${key as string}` : (key as string);
+        const nextPrefix = prefix
+            ? `${prefix}.${key as string}`
+            : (key as string);
 
-        if (node && typeof node === "object" && "_type" in node) {
-            out[key] = await q;
-        } else {
-            out[key] = await buildPaths(q as any, node);
-            isLeaf = false;
+        //   plain descriptor  ────────── event
+        if (
+            node &&
+            typeof node === "object" &&
+            "_type" in node &&
+            !("_args" in node)
+        ) {
+            out[key] = () => ({ chain, path: nextPrefix });
+            continue;
         }
-    }
-    if (isLeaf) {
-        return prefix as string;
+
+        //   storage descriptor ───────── query w/ args
+        if (node && typeof node === "object" && "_args" in node) {
+            out[key] = (...args: any[]) => ({ chain, path: nextPrefix, args });
+            continue;
+        }
+
+        //   deeper pallet subtree
+        out[key] = buildFuncPaths(nextPrefix, node, chain);
     }
     return out;
 }
 
-type ObservablesEventMap = {
-    [V in VirtualChainId]: PathMap<
-        (typeof D)[FromVirtual<V>]["descriptors"]["pallets"]["__event"],
-        `${FromVirtual<V>}.event`
-    >;
+type ObservablesEventMap<V extends VirtualChainId> = FuncTree<
+    (typeof D)[FromVirtual<V>]["descriptors"]["pallets"]["__event"],
+    `event`,
+    FromVirtual<V>
+>;
+
+type ObservablesQueryMap<V extends VirtualChainId> = FuncTree<
+    (typeof D)[FromVirtual<V>]["descriptors"]["pallets"]["__storage"],
+    `storage`,
+    FromVirtual<V>
+>;
+
+type ObservablesMap = {
+    event: { [V in VirtualChainId]: ObservablesEventMap<V> };
+    storage: { [V in VirtualChainId]: ObservablesQueryMap<V> };
 };
 
-type ObservablesQueryMap = {
-    [V in VirtualChainId]: PathMap<
-        (typeof D)[FromVirtual<V>]["descriptors"]["pallets"]["__storage"],
-        `${FromVirtual<V>}.query`
-    >;
-};
-export const Observables = await (async () => {
+export const Observables: Readonly<ObservablesMap> = await (async () => {
     // Build event tree
     const eventEntries = await Promise.all(
         knownChains.map(async (id) => {
-            const vId = toVirtual(id) as VirtualChainId;
+            const vId = toVirtual(id);
             const d = await D[id].descriptors;
-            const pm = (await buildPaths(
-                `${id}.event`,
-                d.events
-            )) as ObservablesEventMap[typeof vId];
+            const pm = (await buildFuncPaths(
+                `event`,
+                d.events,
+                id
+            )) as ObservablesEventMap<typeof vId>;
 
             return [vId, pm] as const;
         })
     );
-    const eventObj = Object.fromEntries(eventEntries) as ObservablesEventMap;
+    const eventObj = Object.fromEntries(eventEntries) as {
+        [V in VirtualChainId]: ObservablesEventMap<V>;
+    };
 
     // Build query tree
     const queryEntries = await Promise.all(
         knownChains.map(async (id) => {
-            const vId = toVirtual(id) as VirtualChainId;
+            const vId = toVirtual(id);
             const d = await D[id].descriptors;
-            const pm = (await buildPaths(
-                `${id}.query`,
-                d.storage
-            )) as ObservablesQueryMap[typeof vId];
+            const pm = (await buildFuncPaths(
+                `storage`,
+                d.storage,
+                id
+            )) as ObservablesQueryMap<typeof vId>;
 
             return [vId, pm] as const;
         })
     );
-    const queryObj = Object.fromEntries(queryEntries) as ObservablesQueryMap;
+    const queryObj = Object.fromEntries(queryEntries) as {
+        [V in VirtualChainId]: ObservablesQueryMap<V>;
+    };
 
-    return { event: eventObj, query: queryObj } as const;
+    return { event: eventObj, storage: queryObj } as const;
 })();
+
+/**
+ * TODO! tests + docs
+ */

--- a/src/app-support/types/descriptor-trees.ts
+++ b/src/app-support/types/descriptor-trees.ts
@@ -11,7 +11,19 @@ import {
 } from "./known-chains";
 
 /**
+ * ## WatchLeaf
  *
+ * The smallest unit of a "thing to watch" under the `Observables` umbrella.
+ * Regardless of which root path we take from `Observables`, all leaves share this
+ * common structure. One `WatchLeaf` always corresponds to a single "entity".
+ *
+ * We can handle more complex watch patterns in a single `TRoute` with lists of
+ * `WatchLeaf`s, or by using a higher level, builder pattern based `WatchCollection` class.
+ *
+ * @property chain - The chain this leaf is for
+ * @property path - The full path to some "entity" we intend to watch
+ * @property args - The arguments to pass to the observable, e.g. `["some-id"]`
+ * @property options - Additional options for the observable, e.g. `{ finalized: true }`
  */
 export type WatchLeaf<
     C extends ChainId = ChainId,
@@ -21,20 +33,62 @@ export type WatchLeaf<
 > = Expand<{ chain: C; path: P; args: A; options: O }>;
 
 /**
- *
+ * Options for `Observables.event` leaves
+ */
+export class EventOptions {
+    constructor(options: {} = {}) {}
+}
+
+/**
+ * Options for `Observables.storage` leaves
+ */
+export class StorageOptions {
+    /**
+     * Specifies whether to hold off on triggering until a change to this leaf's storage
+     * item is finalized— or trigger immedidately when any changes are detected on the "best" block.
+     *
+     * You should only want to set this to `false` if you are doing something that is time sensitive and
+     * can handle changes being reverted at some point in the near future (e.g. real-time gaming or messaging).
+     *
+     * Defaults to `true`.
+     */
+    finalized?: boolean;
+
+    /**
+     * Optionally trigger only on updates/inserts, or only deletions, of the storage
+     * item being watched. If not specified, all changes will trigger.
+     */
+    changeType?: "upsert" | "deleted";
+
+    constructor(
+        options: { finalized?: boolean; changeType?: "upsert" | "deleted" } = {}
+    ) {
+        this.finalized = options.finalized;
+        this.changeType = options.changeType;
+    }
+}
+
+/**
+ * A recursive type that translates a single blockchains `event` & `storage`
+ * descriptors into a Substrate Lambdas `Observables` sub-tree.
  */
 export type FuncTree<T, P extends string, C extends ChainId> = {
     [K in keyof T]: T[K] extends StorageDescriptor<infer Keys, any, any, any>
-        ? (
-              ...args: PartialArgs<Keys>
+        ? // Storage leaf
+          (
+              ...args: [...PartialArgs<Keys>, options?: Expand<StorageOptions>]
           ) => [WatchLeaf<C, `${P}.${K & string}`, PartialArgs<Keys>, {}>]
         : T[K] extends PlainDescriptor<any>
-        ? () => [WatchLeaf<C, `${P}.${K & string}`, [], {}>]
-        : FuncTree<T[K], P extends "" ? K & string : `${P}.${K & string}`, C>;
+        ? // Event leaf
+          (
+              ...args: [options?: Expand<EventOptions>]
+          ) => [WatchLeaf<C, `${P}.${K & string}`, [], {}>]
+        : // Recurse next layer of tree
+          FuncTree<T[K], P extends "" ? K & string : `${P}.${K & string}`, C>;
 };
 
 /**
- *
+ *  Builds a `FuncTree` for a given chain's `descriptors` object.
  */
 async function buildFuncTree<
     C extends ChainId,
@@ -47,7 +101,40 @@ async function buildFuncTree<
 ): Promise<FuncTree<T, P, C> | Promise<() => [WatchLeaf]>> {
     // Leaf node
     if (Object.keys(tree).length === 0) {
-        return (...args: any[]) => [{ chain, path: prefix, args, options: {} }];
+        return (...args: any[]) => {
+            const lastArg = args[args.length - 1];
+            let options = {};
+            let actualArgs = args;
+            if (
+                /**
+                 * Is the last argument an "options" object?
+                 *
+                 * NOTE! In the case that no options are provided, and the last given key
+                 * is an object who's properties all match the available properties some
+                 * "options" object, then this will give a false positive, mistakenly eating
+                 * a key as our "options".
+                 *
+                 * The chances of this conflict actually happening are very low, so for now
+                 * we accept this potential edge case for the sake of nice API design.
+                 */
+                typeof lastArg === "object" &&
+                (Object.keys(lastArg).every((key) =>
+                    Object.keys(new StorageOptions()).find(
+                        (possibleKey) => key == possibleKey
+                    )
+                ) ||
+                    Object.keys(lastArg).every((key) =>
+                        Object.keys(new EventOptions()).find(
+                            (possibleKey) => key == possibleKey
+                        )
+                    ))
+            ) {
+                options = lastArg;
+                actualArgs = args.slice(0, -1);
+            }
+
+            return [{ chain, path: prefix, args: actualArgs, options }];
+        };
     }
 
     // Recursive tree node
@@ -63,25 +150,38 @@ async function buildFuncTree<
     return out;
 }
 
+/**
+ * An `event` FuncTree for a blockchain given by `V`.
+ */
 type ObservablesEventMap<V extends VirtualChainId> = FuncTree<
     (typeof D)[FromVirtual<V>]["descriptors"]["pallets"]["__event"],
     `event`,
     FromVirtual<V>
 >;
 
-type ObservablesQueryMap<V extends VirtualChainId> = FuncTree<
+/**
+ * A `storage` FuncTree for a blockchain given by `V`.
+ */
+type ObservablesStorageMap<V extends VirtualChainId> = FuncTree<
     (typeof D)[FromVirtual<V>]["descriptors"]["pallets"]["__storage"],
     `storage`,
     FromVirtual<V>
 >;
 
+/**
+ * The root `Observables` type.
+ */
 type ObservablesMap = {
     event: { [V in VirtualChainId]: ObservablesEventMap<V> };
-    storage: { [V in VirtualChainId]: ObservablesQueryMap<V> };
+    storage: { [V in VirtualChainId]: ObservablesStorageMap<V> };
 };
 
 /**
+ * ## Observables
  *
+ * The root `Observables` object.
+ *
+ * TODO! docs here
  */
 export const Observables: Readonly<ObservablesMap> = await (async () => {
     // Build event tree
@@ -111,23 +211,20 @@ export const Observables: Readonly<ObservablesMap> = await (async () => {
                 id,
                 `storage`,
                 d.storage
-            )) as ObservablesQueryMap<typeof vId>;
+            )) as ObservablesStorageMap<typeof vId>;
 
             return [vId, pm] as const;
         })
     );
     const queryObj = Object.fromEntries(queryEntries) as {
-        [V in VirtualChainId]: ObservablesQueryMap<V>;
+        [V in VirtualChainId]: ObservablesStorageMap<V>;
     };
 
     return { event: eventObj, storage: queryObj } as const;
 })();
 
-/**
- * TODO! tests + docs
- */
 if (import.meta.vitest) {
-    const { test, expect } = import.meta.vitest;
+    const { test, expect, describe } = import.meta.vitest;
     const { Observables } = await import("./descriptor-trees");
 
     test("Correct event observable", () => {
@@ -153,5 +250,107 @@ if (import.meta.vitest) {
                 options: {},
             },
         ]);
+    });
+
+    describe("Capture WatchLeaf `options`", () => {
+        test("Extracts `options` when available", () => {
+            expect(
+                Observables.storage.polkadotAssetHub.Balances.Account(
+                    "some-id",
+                    { finalized: true }
+                )
+            ).toEqual([
+                {
+                    chain: "polkadot_asset_hub",
+                    path: "storage.Balances.Account",
+                    args: ["some-id"],
+                    options: {
+                        finalized: true,
+                    },
+                },
+            ]);
+
+            expect(
+                Observables.storage.polkadot.Staking.ErasStakersPaged(
+                    10,
+                    "some-id",
+                    { changeType: "upsert" }
+                )
+            ).toEqual([
+                {
+                    chain: "polkadot",
+                    path: "storage.Staking.ErasStakersPaged",
+                    args: [10, "some-id"],
+                    options: {
+                        changeType: "upsert",
+                    },
+                },
+            ]);
+
+            expect(
+                Observables.storage.polkadotAssetHub.Balances.Account({
+                    finalized: true,
+                })
+            ).toEqual([
+                {
+                    chain: "polkadot_asset_hub",
+                    path: "storage.Balances.Account",
+                    args: [],
+                    options: {
+                        finalized: true,
+                    },
+                },
+            ]);
+        });
+
+        test("options should be empty when no options given", () => {
+            expect(
+                Observables.storage.polkadotAssetHub.Balances.Account()
+            ).toEqual([
+                {
+                    chain: "polkadot_asset_hub",
+                    path: "storage.Balances.Account",
+                    args: [],
+                    options: {},
+                },
+            ]);
+        });
+
+        test("Decide last argument is *not* options even when it is a object shaped key", () => {
+            const st_obs =
+                Observables.storage.polkadotAssetHub.PolkadotXcm.SupportedVersion(
+                    10,
+                    {
+                        type: "V2",
+                        value: {
+                            parents: 43,
+                            interior: {
+                                type: "Here",
+                                value: undefined,
+                            },
+                        },
+                    }
+                );
+            expect(st_obs).toEqual([
+                {
+                    chain: "polkadot_asset_hub",
+                    path: "storage.PolkadotXcm.SupportedVersion",
+                    args: [
+                        10,
+                        {
+                            type: "V2",
+                            value: {
+                                parents: 43,
+                                interior: {
+                                    type: "Here",
+                                    value: undefined,
+                                },
+                            },
+                        },
+                    ],
+                    options: {},
+                },
+            ]);
+        });
     });
 }

--- a/src/app-support/types/descriptor-trees.ts
+++ b/src/app-support/types/descriptor-trees.ts
@@ -17,7 +17,7 @@ export type WatchLeaf<
     C extends ChainId = ChainId,
     P extends string = string,
     A extends any[] = any[],
-    O extends object = object
+    O extends object = any
 > = Expand<{ chain: C; path: P; args: A; options: O }>;
 
 /**

--- a/src/app-support/types/descriptor-trees.ts
+++ b/src/app-support/types/descriptor-trees.ts
@@ -1,4 +1,6 @@
+import { PlainDescriptor, StorageDescriptor } from "polkadot-api";
 import * as D from "@polkadot-api/descriptors";
+
 import { Expand, PartialArgs } from "./helpers";
 import {
     knownChains,
@@ -7,7 +9,6 @@ import {
     VirtualChainId,
     ChainId,
 } from "./known-chains";
-import { PlainDescriptor, StorageDescriptor } from "polkadot-api";
 
 /**
  *

--- a/src/app-support/types/helpers.ts
+++ b/src/app-support/types/helpers.ts
@@ -1,6 +1,3 @@
-import { PlainDescriptor, StorageDescriptor } from "polkadot-api";
-import { ChainId } from "./known-chains";
-
 /**
  * Utility type to expand a type into its properties.
  *
@@ -19,45 +16,14 @@ export type Split<
     : [S];
 
 /**
- *  Union of `[] | [key1] | [key1, key2] | ...` across some set of keys
+ *  Union of `[] | [arg1] | [arg1, arg2] | ...` across some `Args`
  */
-export type PartialArgs<T extends readonly any[]> = T extends [
+export type PartialArgs<Args extends readonly any[]> = Args extends [
     ...infer Rest,
     any
 ]
-    ? PartialArgs<Rest> | T
-    : T;
-
-/**
- * The structure of a payload under `Observables.event`
- */
-type EventPayload<Value> = Value;
-
-/**
- * The structure of a payload under `Observables.storage`
- */
-type StoragePayload<Key, Value> = Expand<{
-    key: Key;
-    value: Value;
-}>;
-
-/**
- * Extract specific type inside of a descriptor tree, given by a list of type strings
- */
-export type PayloadLookup<TreeNode, Path extends readonly string[]> =
-    // Pop top key from path
-    Path extends [infer K, ...infer Rest extends string[]]
-        ? // More path— dig deeper
-          K extends keyof TreeNode
-            ? PayloadLookup<TreeNode[K], Rest>
-            : never
-        : // Storage leaf
-        TreeNode extends StorageDescriptor<infer Key, infer Value, any, any>
-        ? StoragePayload<Key, Value>
-        : // Event leaf
-        TreeNode extends PlainDescriptor<infer Value>
-        ? EventPayload<Value>
-        : never;
+    ? PartialArgs<Rest> | Args
+    : Args;
 
 /**
  * Tests covered by sibling files

--- a/src/app-support/types/index.ts
+++ b/src/app-support/types/index.ts
@@ -1,3 +1,3 @@
 export * from "./apps";
-export * from "./descriptor-trees";
+export * from "./observables";
 export * from "./known-chains";

--- a/src/app-support/types/observables.ts
+++ b/src/app-support/types/observables.ts
@@ -227,7 +227,7 @@ export const Observables: Readonly<ObservablesMap> = await (async () => {
 
 if (import.meta.vitest) {
     const { test, expect, describe } = import.meta.vitest;
-    const { Observables } = await import("./descriptor-trees");
+    const { Observables } = await import("./observables");
 
     test("Correct event observable", () => {
         const ev_obs = Observables.event.polkadot.Balances.Transfer();

--- a/src/app-support/types/payload.ts
+++ b/src/app-support/types/payload.ts
@@ -2,7 +2,7 @@ import * as D from "@polkadot-api/descriptors";
 import { PlainDescriptor, StorageDescriptor } from "polkadot-api";
 
 import { Expand, Split } from "./helpers";
-import { WatchLeaf } from "./descriptor-trees";
+import { WatchLeaf } from "./observables";
 
 /**
  * The structure of a payload under `Observables.event`

--- a/src/app-support/types/payload.ts
+++ b/src/app-support/types/payload.ts
@@ -1,0 +1,46 @@
+import * as D from "@polkadot-api/descriptors";
+import { PlainDescriptor, StorageDescriptor } from "polkadot-api";
+
+import { Expand, Split } from "./helpers";
+import { WatchLeaf } from "./descriptor-trees";
+
+/**
+ * The structure of a payload under `Observables.event`
+ */
+type EventPayload<Value> = Value;
+
+/**
+ * The structure of a payload under `Observables.storage`
+ */
+type StoragePayload<Key, Value> = Expand<{
+    key: Key;
+    value: Value;
+}>;
+
+/**
+ * Extract specific type inside of a descriptor tree, given by a list of type strings
+ */
+export type PayloadLookup<
+    TreeNode,
+    Path extends readonly string[]
+> = Path extends [infer K, ...infer Rest extends string[]]
+    ? // Pop top key from path More path— dig deeper
+      K extends keyof TreeNode
+        ? PayloadLookup<TreeNode[K], Rest>
+        : never
+    : // Storage leaf
+    TreeNode extends StorageDescriptor<infer Key, infer Value, any, any>
+    ? StoragePayload<Key, Value>
+    : // Event leaf
+    TreeNode extends PlainDescriptor<infer Value>
+    ? EventPayload<Value>
+    : never;
+
+export type Payload<WL extends WatchLeaf> = PayloadLookup<
+    {
+        event: (typeof D)[WL["chain"]]["descriptors"]["pallets"]["__event"];
+
+        storage: (typeof D)[WL["chain"]]["descriptors"]["pallets"]["__storage"];
+    },
+    Split<WL["path"]>
+>;

--- a/src/apps/election-watch/index.ts
+++ b/src/apps/election-watch/index.ts
@@ -10,7 +10,7 @@ export default App(description, {
      * Triggers for all phase transition events
      */
     watching:
-        Observables.event.polkadot.ElectionProviderMultiPhase.PhaseTransitioned,
+        Observables.event.polkadot.ElectionProviderMultiPhase.PhaseTransitioned(),
     trigger: (_, c) => {
         return true;
     },

--- a/src/apps/polkadot-election-dataset-aggregator/index.ts
+++ b/src/apps/polkadot-election-dataset-aggregator/index.ts
@@ -12,7 +12,7 @@ export default App(description, {
      * Triggers when `Signed` phase begins. This should trigger once per era.
      */
     watching:
-        Observables.event.polkadot.ElectionProviderMultiPhase.PhaseTransitioned,
+        Observables.event.polkadot.ElectionProviderMultiPhase.PhaseTransitioned(),
     trigger: (transition, c) => {
         return transition.to.type == "Signed";
     },

--- a/src/apps/staking-miner/index.ts
+++ b/src/apps/staking-miner/index.ts
@@ -11,7 +11,7 @@ export default App(description, {
      * Triggers when `Signed` phase begins. This should trigger once per era.
      */
     watching:
-        Observables.event.polkadot.ElectionProviderMultiPhase.PhaseTransitioned,
+        Observables.event.polkadot.ElectionProviderMultiPhase.PhaseTransitioned(),
     trigger: (_, c) => {
         return false;
     },

--- a/tests/client.spec.ts
+++ b/tests/client.spec.ts
@@ -142,4 +142,19 @@ describe("Substrate Lambdas Client", async () => {
             ).toEqual(10_000_000_000n);
         });
     });
+
+    describe("Routes", async () => {
+        it("should handle `Observables.event` leaves, and give payload in expected format", async () => {
+            expect.fail("not implemented");
+        });
+        it("should handle all caputured events from `Observables.event` with .all()", async () => {
+            expect.fail("not implemented");
+        });
+        it("should handle `Observables.storage` leaves and give payload in expected format, regardless of `.watchEntries` or `.watchValue`", async () => {
+            expect.fail("not implemented");
+        });
+        it("should filter `delete`, `upsert` payloads on `Observables.storage` according to `WatchLeaf.options`", async () => {
+            expect.fail("not implemented");
+        });
+    });
 });

--- a/tests/client.spec.ts
+++ b/tests/client.spec.ts
@@ -13,7 +13,7 @@ import { appsDir, mockGetAPI } from "./mock";
 import { MultiAddress } from "@polkadot-api/descriptors";
 import fs from "fs";
 import path from "path";
-import { TAppModule, WatchPath } from "@lambdas/app-support";
+import { TAppModule, WatchLeaf } from "@lambdas/app-support";
 import { getPolkadotSigner } from "polkadot-api/signer";
 import { Binary } from "polkadot-api";
 import { cryptoWaitReady } from "@polkadot/util-crypto";
@@ -47,7 +47,7 @@ async function getSpiedOnRoutes() {
         try {
             const appModule = (
                 await import(path.join(appsDir, appName, "index.ts"))
-            ).default as TAppModule<WatchPath[]>;
+            ).default as TAppModule<WatchLeaf[][]>;
 
             acc[appName] = appModule.routes.map((route) => {
                 return {

--- a/tests/mock-apps/single-event/index.ts
+++ b/tests/mock-apps/single-event/index.ts
@@ -1,7 +1,7 @@
 import { App, Observables } from "@lambdas/app-support";
 
 export default App("", {
-    watching: Observables.event.polkadot.Balances.Transfer,
+    watching: Observables.event.polkadot.Balances.Transfer(),
     trigger: (tx, c) => {
         console.log("basic test trigger hit!");
         console.log(tx);

--- a/tests/mock-apps/single-query/index.ts
+++ b/tests/mock-apps/single-query/index.ts
@@ -2,7 +2,7 @@ import { App, Observables } from "@lambdas/app-support";
 
 export default App("", {
     watching:
-        Observables.event.polkadot.ElectionProviderMultiPhase.PhaseTransitioned,
+        Observables.event.polkadot.ElectionProviderMultiPhase.PhaseTransitioned(),
 
     trigger: (_, c) => {
         console.log("basic test trigger hit!");


### PR DESCRIPTION
Related to issues #12 & #13

- Updated `WatchPath`, which was just a structured string, into an object that can scale to more complex features
```ts
export type WatchLeaf<
    C extends ChainId = ChainId,
    P extends string = string,
    A extends any[] = any[],
    O extends object = EventOptions & StorageOptions
> = Expand<{ chain: C; path: P; args: A; options: O }>;
```
- turned all leaves of `Observables` into functions which can take
    - `...args` which are keys for `storage` observables
    - `options` which include peripheral settings on a `WatchLeaf`
    - ex: `Observables.event.polkadot.ElectionProviderMultiPhase.PhaseTransitioned` --> `Observables.event.polkadot.ElectionProviderMultiPhase.PhaseTransitioned({ finalized: false })`
- updated & added tests
- updated core `app-handler` logic to handle `options` & `storage` *observables* with keys

### Still to do
- integration tests to validate new `app-handler` logic on storage
- add `.all()` escape no `event` *observables* which gives a `WatchLeaf[]` for all events on that chain/pallet
- Update `Payload` type to properly give a union of payloads across a route's `WatchLeaf[]`